### PR TITLE
Add Preprod support

### DIFF
--- a/address.go
+++ b/address.go
@@ -193,7 +193,15 @@ func (addr *Address) UnmarshalCBOR(data []byte) error {
 
 // Bytes returns the CBOR encoding of the Address as bytes.
 func (addr *Address) Bytes() []byte {
-	addrBytes := []byte{byte(addr.Type<<4) | (byte(addr.Network) & 0xFF)}
+	var networkByte uint8
+	switch addr.Network {
+	case Testnet, Preprod:
+		networkByte = 0
+	case Mainnet:
+		networkByte = 1
+	}
+
+	addrBytes := []byte{byte(addr.Type<<4) | (networkByte & 0xFF)}
 	switch addr.Type {
 	case Base, Base + 1, Base + 2, Base + 3:
 		addrBytes = append(addrBytes, addr.Payment.Hash()...)
@@ -309,9 +317,10 @@ func Blake224Hash(b []byte) ([]byte, error) {
 }
 
 func getHrp(network Network) string {
-	if network == Testnet {
+	switch network {
+	case Testnet, Preprod:
 		return "addr_test"
-	} else {
+	default:
 		return "addr"
 	}
 }

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -24,8 +24,12 @@ type BlockfrostNode struct {
 // NewNode returns a new instance of BlockfrostNode.
 func NewNode(network cardano.Network, projectID string) cardano.Node {
 	server := blockfrost.CardanoMainNet
-	if network == cardano.Testnet {
+	switch network {
+	case cardano.Testnet:
 		server = blockfrost.CardanoTestNet
+	case cardano.Preprod:
+		// We hardcode the preprod url here until blockfrost supports Preprod type.
+		server = "https://cardano-preprod.blockfrost.io/api/v0"
 	}
 
 	return &BlockfrostNode{

--- a/primitive.go
+++ b/primitive.go
@@ -14,13 +14,19 @@ type Network byte
 const (
 	Testnet Network = 0
 	Mainnet Network = 1
+	Preprod Network = 2
 )
 
 // String implements Stringer.
 func (n Network) String() string {
-	if n == Mainnet {
+	switch n {
+	case Testnet:
+		return "testnet"
+	case Mainnet:
 		return "mainnet"
-	} else {
+	case Preprod:
+		return "preprod"
+	default:
 		return "testnet"
 	}
 }


### PR DESCRIPTION
This PR add new network type preprod for testnet. The blockfrost API server does not have preprod type yet, so we have to hardcode the blockfrost API URL for preprod. 

This could be extended to support Testnet Preview

Close https://github.com/echovl/cardano-go/issues/35

@echovl 