### PR TITLE
Fix MultiAsset Stringer in primitive.go

### DIFF
--- a/primitive.go
+++ b/primitive.go
@@ -321,7 +321,8 @@ func (ma MultiAsset) String() string {
 	vMap := map[string]uint64{}
 	for _, pool := range ma.Keys() {
 		for _, assets := range ma.Get(pool).Keys() {
-			vMap[assets.String()] = uint64(ma.Get(pool).Get(assets))
+			key := fmt.Sprintf("%s %s", pool.String(), assets.String())
+			vMap[key] = uint64(ma.Get(pool).Get(assets))
 		}
 	}
 	return fmt.Sprintf("%+v", vMap)


### PR DESCRIPTION
We can't just ignore the policy id here. When two assets with different policies have the same name (eg default values like "Asset 1" or empty, this overwrites previously set values and returns wrong results)