### PR TITLE
Add support for partially signed tx, closes #38

### DIFF
--- a/tx_builder.go
+++ b/tx_builder.go
@@ -15,6 +15,8 @@ type TxBuilder struct {
 	pkeys    []crypto.PrvKey
 
 	changeReceiver *Address
+
+	additionalWitnesses uint
 }
 
 // NewTxBuilder returns a new instance of TxBuilder.
@@ -46,6 +48,12 @@ func (tb *TxBuilder) SetTTL(ttl uint64) {
 // SetFee sets the transactions's fee.
 func (tb *TxBuilder) SetFee(fee Coin) {
 	tb.tx.Body.Fee = fee
+}
+
+// SetAdditionalWitnesses sets future witnesses for a partially signed transction.
+// This is useful to compute the real length and so fee in advance
+func (tb *TxBuilder) SetAdditionalWitnesses(witnesses uint) {
+	tb.additionalWitnesses = witnesses
 }
 
 // AddAuxiliaryData adds auxiliary data to the transaction.
@@ -143,6 +151,14 @@ func (tb *TxBuilder) MinCoinsForTxOut(txOut *TxOutput) Coin {
 func (tb *TxBuilder) calculateMinFee() Coin {
 	txBytes := tb.tx.Bytes()
 	txLength := uint64(len(txBytes))
+	// for each additional witnesses there will be an additional 100 bytes,
+	// (32 public key, 64 signature, 4 index/key in cbor)
+	txLength += uint64(tb.additionalWitnesses * 100)
+	// apparently that is not enough, so just consider 1 additional byte
+	// for each additional witness after the first
+	if tb.additionalWitnesses > 1 {
+		txLength += uint64(tb.additionalWitnesses - 1)
+	}
 	return tb.protocol.MinFeeA*Coin(txLength) + tb.protocol.MinFeeB
 }
 

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -233,7 +233,7 @@ func (tb *TxBuilder) addChangeIfNeeded(inputAmount, outputAmount *Value) error {
 
 	if inputOutputCmp := inputAmount.Cmp(outputAmount); inputOutputCmp == -1 || inputOutputCmp == 2 {
 		return fmt.Errorf(
-			"insuficient input in transaction, got %v want atleast %v",
+			"insufficient input in transaction, got %v want atleast %v",
 			inputAmount,
 			outputAmount,
 		)


### PR DESCRIPTION
* allow to set additional witnesses for partially signed tx preparation
* change calculateMinFee to consider additional witnesses that will increase the tx length. It is still not clear how to precisely calculate the bytes for witnesses, in this implementation for each additional witnesses there will be an additional 100 bytes, (32 public key, 64 signature, 4 index/key in cbor). Those are not actually enough so we are considering 1 additional byte for each additional witness after the first.

